### PR TITLE
feat: Conditionally link degree issuer name to its website if available.

### DIFF
--- a/resources/views/partials/about/education.blade.php
+++ b/resources/views/partials/about/education.blade.php
@@ -13,7 +13,13 @@
                 <br>
 
                 {{-- Issuer name --}}
-                <em>{{ $degree->issuer->name ?? 'Unknown issuer' }}</em>
+                @if($degree->issuer->website)
+                    <a href="{{ $degree->issuer->website }}" target="_blank" rel="noopener noreferrer">
+                        <em>{{ $degree->issuer->name ?? 'Unknown issuer' }}</em>
+                    </a>
+                @else
+                    <em>{{ $degree->issuer->name ?? 'Unknown issuer' }}</em>
+                @endif
                 <br>
 
                 {{-- Formatted start and end dates --}}


### PR DESCRIPTION
Fixes #36

### Summary
This PR updates the "About" page to make education issuer names clickable links when a website URL is available.

### Changes
- Modified [resources/views/partials/about/education.blade.php](cci:7://file:///home/muntazir/Desktop/git/personal-website/resources/views/partials/about/education.blade.php:0:0-0:0).
- Checked if `$degree->issuer->website` is present.
- Wrapped the issuer name in an anchor tag (`<a>`) linking to the website if available.
- Added `target="_blank"` and `rel="noopener noreferrer"` to open links in a new tab securely.
- Ensured that issuers without a website continue to display as plain text.