### PR TITLE
Feat/spoken language seeder

### DIFF
--- a/database/factories/SpokenLanguageFactory.php
+++ b/database/factories/SpokenLanguageFactory.php
@@ -17,7 +17,12 @@ class SpokenLanguageFactory extends Factory
     public function definition(): array
     {
         return [
-            //
+            'profile_id' => \App\Models\Profile::factory(),
+            'name' => $this->faker->languageCode(), // Using languageCode as a proxy for language name since 'language' might not be available in all faker providers, adjusting if needed. Actually, faker->languageName() is better if available but often languageCode or just a random word is used. Let's use a random element from a list for better realism or just a word.
+            // Better approach for 'name':
+            'name' => $this->faker->randomElement(['English', 'Spanish', 'French', 'German', 'Chinese', 'Japanese', 'Russian', 'Portuguese', 'Arabic', 'Hindi']),
+            'proficiency' => $this->faker->randomElement(['Native', 'Fluent', 'Professional', 'Intermediate', 'Beginner']),
+            'is_native' => $this->faker->boolean(20), // 20% chance of being native
         ];
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -26,6 +26,7 @@ class DatabaseSeeder extends Seeder
             $this->call([
                 \Database\Seeders\ProfileSeeder::class,
                 \Database\Seeders\ProfileLinkSeeder::class,
+                \Database\Seeders\SpokenLanguageSeeder::class,
             ]);
         }
     }

--- a/database/seeders/SpokenLanguageSeeder.php
+++ b/database/seeders/SpokenLanguageSeeder.php
@@ -12,6 +12,18 @@ class SpokenLanguageSeeder extends Seeder
      */
     public function run(): void
     {
-        //
+        $profiles = \App\Models\Profile::all();
+
+        if ($profiles->isEmpty()) {
+            $this->command->info('No profiles found. Skipping SpokenLanguage seeding.');
+            return;
+        }
+
+        foreach ($profiles as $profile) {
+            // Create 1-3 spoken languages for each profile
+            \App\Models\SpokenLanguage::factory(rand(1, 3))->create([
+                'profile_id' => $profile->id,
+            ]);
+        }
     }
 }


### PR DESCRIPTION
### Changes Implemented

- **Factory Created**: Implemented [SpokenLanguageFactory](cci:2://file:///home/muntazir/Desktop/git2/personal-website/database/factories/SpokenLanguageFactory.php:9:0-22:1) to generate random language data, supporting realistic test datasets.
- **Seeder Created**: Implemented [SpokenLanguageSeeder](cci:2://file:///home/muntazir/Desktop/git2/personal-website/database/seeders/SpokenLanguageSeeder.php:7:0-16:1) to assign 1-3 random spoken languages to each existing profile.
- **DatabaseSeeder Updated**: Registered [SpokenLanguageSeeder](cci:2://file:///home/muntazir/Desktop/git2/personal-website/database/seeders/SpokenLanguageSeeder.php:7:0-16:1) in [DatabaseSeeder.php](cci:7://file:///home/muntazir/Desktop/git2/personal-website/database/seeders/DatabaseSeeder.php:0:0-0:0) to ensure it runs during local development seeding.

### Notes

- This enables developers to easily populate the database with spoken language data for testing the "About" page and other profile-related features.
- Run the seeder using: `php artisan db:seed --class=SpokenLanguageSeeder`