### PR TITLE
refactor(seeders): update UserSeeder to use env-based name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,9 @@ APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
 
-# main admin user email and password for seeding
+# main admin user email, name and password for seeding
 ADMIN_EMAIL=test@example.com
+ADMIN_NAME="Main User"
 ADMIN_PASSWORD=secret123
 
 APP_LOCALE=en

--- a/database/seeders/ProductionDatabaseSeeder.php
+++ b/database/seeders/ProductionDatabaseSeeder.php
@@ -20,7 +20,7 @@ class ProductionDatabaseSeeder extends Seeder
     public function run(): void
     {
         $this->call([
-            ProductionUserSeeder::class,
+            UserSeeder::class,
             OrganizationSeeder::class,
             ProductionProfileSeeder::class,
             ProductionCertificateSeeder::class,

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -18,7 +18,7 @@ class UserSeeder extends Seeder
         User::updateOrCreate(
             ['email' => env('ADMIN_EMAIL')],
             [
-                'name' => 'Test User',
+                'name' => env('ADMIN_NAME'),
                 'password' => Hash::make(env('ADMIN_PASSWORD')),
                 'email_verified_at' => now(),
             ]


### PR DESCRIPTION
## Tasks
- [x] Modify `UserSeeder` to use `ADMIN_NAME` from `.env` for the main user
- [x] Remove `ProductionUserSeeder` (if applicable)
- [x] Update `ProductionDatabaseSeeder` to call `UserSeeder` instead of `ProductionUserSeeder`
- [x] Test `php artisan migrate:fresh --seed` in both local and production environments
- [x] Update `.env.example` to include `ADMIN_NAME`
