### PR TITLE
refactor(seeders): standardize profile seeding

### DIFF
--- a/database/seeders/ProductionDatabaseSeeder.php
+++ b/database/seeders/ProductionDatabaseSeeder.php
@@ -22,7 +22,7 @@ class ProductionDatabaseSeeder extends Seeder
         $this->call([
             UserSeeder::class,
             OrganizationSeeder::class,
-            ProductionProfileSeeder::class,
+            ProfileSeeder::class,
             ProductionCertificateSeeder::class,
             ProductionDegreeSeeder::class,
             ProductionProfileLinkSeeder::class,

--- a/database/seeders/ProfileSeeder.php
+++ b/database/seeders/ProfileSeeder.php
@@ -5,22 +5,43 @@ namespace Database\Seeders;
 use Illuminate\Database\Seeder;
 use App\Models\User;
 use App\Models\Profile;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Arr;
 
 class ProfileSeeder extends Seeder
 {
-    /**
-     * Run the database seeds.
-     */
     public function run(): void
-    {   
-        if (!app()->environment('local')) {
-            return;
+    {
+        // Get the main user created by UserSeeder
+        $user = User::first();
+
+        // Determine the JSON path for the main profile based on environment
+        //    - Production uses a separate folder to allow different default profiles (gitignored)
+        $jsonPath = app()->environment('production') 
+            ? database_path('seeders/production/data/main_profile.json')
+            : database_path('seeders/data/main_profile.json');
+
+        // Check if JSON file exists before attempting to read
+        if (File::exists($jsonPath)) {
+            // decode JSON into array
+            $data = json_decode(File::get($jsonPath), true); 
+
+            // Ensure 'display_name' exists, other fields are optional
+            if (!empty($data) && isset($data['display_name'])) {
+                // only expected fields
+                $profileData = Arr::only($data, ['display_name', 'bio', 'image']);
+
+                // Update or create main profile
+                Profile::updateOrCreate(
+                    ['user_id' => $user->id], 
+                    $profileData 
+                );
+            }
         }
 
-        $user = User::first(); // the user created in DatabaseSeeder
-
-        Profile::factory()->count(2)->create([
-            'user_id' => $user->id, // explicitly link to the main user
-        ]);
+        // Only in local environment, create extra demo profiles
+        if (app()->environment('local')) {
+            Profile::factory()->count(5)->create();
+        }
     }
 }

--- a/database/seeders/data/main_profile.json
+++ b/database/seeders/data/main_profile.json
@@ -1,0 +1,5 @@
+{
+  "display_name": "Main User Local",
+  "bio": "This is the main demo user profile for local environment.",
+  "image": null
+}


### PR DESCRIPTION
## Objective
Refactor profile seeding to eliminate redundancy between local and production seeders, and standardize how profiles are created across environments.

## Changes
- Unified ProfileSeeder handles main profile creation from JSON for both environments
- Demo profiles only created in local
- ProductionDatabaseSeeder now calls ProfileSeeder as well
- Ensures migrate:fresh --seed works correctly in both local and production