### PR TITLE
refactor(home): unify hero content into page header component

### DIFF
--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -1,8 +1,8 @@
 <x-site-layout 
     :title="'Home | Mamalikidou Anastasia'"
     :header="view('partials.page-header', [
-        'title' => 'Home',
-        'subtitle' => 'Welcome to my website!'
+        'title' => 'Hello! I\'m Anastasia',
+        'subtitle' => 'A recent BEng graduate in Computer Science and Engineering. I enjoy building full-stack web applications with a focus on accessibility, scalability, and learning new technologies along the way.'
         ])"
 >
     @include('partials.home.hero')

--- a/resources/views/partials/home/hero.blade.php
+++ b/resources/views/partials/home/hero.blade.php
@@ -1,6 +1,4 @@
 <section id="hero" class="hero">
-    <h2>Hello! I'm Anastasia</h2>
-    <p>A recent BEng graduate in Computer Science and Engineering. I enjoy building full-stack web applications with a focus on accessibility, scalability, and learning new technologies along the way.</p>
     <p>Here you'll find some of my projects, experiments, and ongoing explorations in web development. Feel free to take a look around!</p>
     <a href="{{ route('projects') }}" class="cta">See My Projects →</a>
 </section>


### PR DESCRIPTION
Moved greeting and bio text from hero section into page-header title and subtitle.

Hero section now focuses on description and link rather than repeating welcoming

> No visual changes apart from content relocation.