### PR TITLE
feat(seo): add canonical meta tag to layout

### DIFF
--- a/resources/views/components/site-layout.blade.php
+++ b/resources/views/components/site-layout.blade.php
@@ -15,6 +15,8 @@
 
         <title>{{ $title }}</title>
         <meta name="description" content="{{ $description }}">
+
+        <link rel="canonical" href="https://a-mamal.com">
         
         <meta name="theme-color" content="#555">
         @vite('resources/css/app.css')


### PR DESCRIPTION
Description

Add `<link rel="canonical" href="https://a-mamal.com">` tag in the main layout `<head>` so all pages point to the preferred canonical URL. This helps with SEO.

> Notes
- The canonical URL is fixed to `https://a-mamal.com`.
- This does not redirect `HTTP` or `www` traffic yet; a separate issue will handle `.htaccess` redirects.