### PR TITLE
fix(seo): make canonical tag dynamic and enforce HTTPS base

### DIFF
--- a/resources/views/components/site-layout.blade.php
+++ b/resources/views/components/site-layout.blade.php
@@ -16,7 +16,7 @@
         <title>{{ $title }}</title>
         <meta name="description" content="{{ $description }}">
 
-        <link rel="canonical" href="https://a-mamal.com">
+        <link rel="canonical" href="https://a-mamal.com{{ request()->getRequestUri() }}">
         
         <meta name="theme-color" content="#555">
         @vite('resources/css/app.css')


### PR DESCRIPTION
Replace fixed canonical URL with a dynamic version that preserves the current path while enforcing the canonical HTTPS base domain.

This prevents all pages from pointing to the homepage as canonical.

> Redirect enforcement via .htaccess remains a separate concern.