### PR TITLE
feat(seeders): update SpokenLanguageSeeder with defaults and JSON support

### DIFF
--- a/database/seeders/SpokenLanguageSeeder.php
+++ b/database/seeders/SpokenLanguageSeeder.php
@@ -4,6 +4,9 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\File;
+use \App\Models\Profile;
+use App\Models\SpokenLanguage;
 
 class SpokenLanguageSeeder extends Seeder
 {
@@ -12,18 +15,72 @@ class SpokenLanguageSeeder extends Seeder
      */
     public function run(): void
     {
-        $profiles = \App\Models\Profile::all();
+        // Fetch all profiles that will receive spoken languages
+        $profiles = Profile::all();
 
+        // If there are no profiles, stop seeding
         if ($profiles->isEmpty()) {
             $this->command->info('No profiles found. Skipping SpokenLanguage seeding.');
             return;
         }
 
-        foreach ($profiles as $profile) {
-            // Create 1-3 spoken languages for each profile
-            \App\Models\SpokenLanguage::factory(rand(1, 3))->create([
-                'profile_id' => $profile->id,
-            ]);
+        // JSON path (same for local and production)
+        $jsonPath = database_path('seeders/data/spoken_languages.json');
+
+        // Ensure the JSON file exists
+        if (!File::exists($jsonPath)) {
+            $this->command->warn("Spoken languages JSON not found: $jsonPath");
+            return;
         }
+
+        // Decode JSON into an array of language names
+        $languages = json_decode(File::get($jsonPath), true);
+
+        // Validate JSON
+        if (!is_array($languages)) {
+            $this->command->error("Invalid JSON format in $jsonPath");
+            return;
+        }
+
+        // Default languages for the first profile
+        $defaultLanguages = [
+            ['name' => 'English',   'proficiency' => 'C2',      'is_native' => false],
+            ['name' => 'Greek',     'proficiency' => 'Native',  'is_native' => true ],
+            ['name' => 'Spanish',   'proficiency' => 'Beginner','is_native' => false],
+        ];
+
+        foreach ($defaultLanguages as $data) {
+            SpokenLanguage::updateOrCreate(
+                [
+                    'profile_id' => 1,
+                    'name' => $data['name'],
+                ],
+                [
+                    'proficiency' => $data['proficiency'],
+                    'is_native' => $data['is_native'],
+                ]
+            );
+        }
+
+        // Random/demo languages for other profiles (local only)
+        if (app()->environment('local')) {
+            foreach ($profiles as $profile) {
+                
+                // Skip first profile to avoid duplicates
+                if ($profile->id === 1) continue;
+
+                // Select random languages from the dataset
+                $selectedLanguages = collect($languages)->random(rand(1, 3));
+                
+                foreach ($selectedLanguages as $language) {
+                    // Use factory for random fields, override language + profile
+                    SpokenLanguage::factory()->create([
+                        'profile_id' => $profile->id,
+                        'name' => $language
+                    ]);
+                }
+            }
+        }
+        $this->command->info('Spoken languages seeded successfully.');
     }
 }


### PR DESCRIPTION
## Description

This PR updates the `SpokenLanguageSeeder` to improve seeding of spoken languages:

- Adds default languages for the first profile to mirror production:
  - English (C2)
  - Greek (Native)
  - Spanish (Beginner)
- Seeds random/demo languages for other profiles (local environment only) using a JSON dataset.
- Ensures seeding works for both local and production environments.
- Validates that the JSON file exists and has the correct format.

## Testing

1. Run `php artisan db:seed --class=SpokenLanguageSeeder`.
2. Verify that the first profile has the three default languages.
3. Verify that other profiles (local environment only) receive 1-3 random languages from the JSON dataset.