### PR TITLE
style(about): add hover, typography, and highlight/question classes

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -539,7 +539,37 @@ section h2 {
     border: 1px solid var(--color-border-section);
     background-color: var(--color-surface-30);
     box-shadow: var(--shadow-card-sm);
-    gap: var(--space-xs);
+    gap: var(--space-sm);
+    transition: 
+        transform 0.2s ease,
+        box-shadow 0.2s ease,
+        border-color 0.2s ease;
+}
+
+.about-section:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-card-md);
+    border-color: var(--color-border-card);
+}
+
+
+.about-section h3 {
+    font-size: var(--font-size-lg);
+    color: var(--color-primary);
+    margin-bottom: var(--space-xs);
+}
+
+.about-section p {
+    font-size: var(--font-size-md);
+    line-height: var(--line-height-lg);
+    color: var(--color-text-primary);
+}
+
+.about-section p.highlight {
+    font-style: italic;
+    color: var(--color-text-primary);
+    border-left: 3px solid var(--color-secondary);
+    padding-left: var(--space-sm);
 }
 
 .about-section p.card-meta a,

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -572,6 +572,11 @@ section h2 {
     padding-left: var(--space-sm);
 }
 
+.about-section p.question {
+    font-style: italic;
+    color: var(--color-text-primary);
+}
+
 .about-section p.card-meta a,
 .about-section p.card-meta a:visited {
     text-decoration: none;

--- a/resources/views/partials/about/site-community.blade.php
+++ b/resources/views/partials/about/site-community.blade.php
@@ -7,6 +7,9 @@
     <p>
         I do not wish to associate with racism, sexism, homophobia, ableism, or other forms of discrimination.
         That applies to all of my work.
+    </p>
+    <p class="highlight">
         While learning (and unlearning) is important, the goal is to remain open, do our best to educate ourselves, and move away from behaviours that are harmful.
     </p>
+    
 </section>

--- a/resources/views/partials/about/site-intro.blade.php
+++ b/resources/views/partials/about/site-intro.blade.php
@@ -5,7 +5,9 @@
         It is my first project built with Laravel, where I began exploring Eloquent and Blade while trying to build something real.
         As a recent graduate, I wanted to invest in my skills and create a place where I could experiment, learn, and document my progress.
         I'm a curious mammal, full of ideas and questions, so it didn't take long for me to dive in.
-        But what if this time I didn't keep it to myself? Everything has a starting point, and this was one of them.
+    </p>
+    <p class="question">But what if this time I didn't keep it to myself?</p> 
+    <p>Everything has a starting point, and this was one of them.
         I got my domain names, hosting, and just started.
     </p>
 </section>

--- a/resources/views/partials/about/site-learning.blade.php
+++ b/resources/views/partials/about/site-learning.blade.php
@@ -9,16 +9,20 @@
 
     <p>
         I clearly remember starting out, learning about GitHub, conventional commits, etc. 
-        I'm still learning and I am far from perfect but really, who and what is?
-        Everything and everyone is evolving. So why keep the current version a secret? 
-    </p>
+        I'm still learning and I am far from perfect
+    </p> 
+    <p class="question">But really, who and what is?</p>
+    <p class="highlight">Everything and everyone is evolving. So why keep the current version a secret? </p>
+        
+    
 
     <p>
         Well, that's great to say but, it's just words. 
-        Have I really learned to feel exposed? To a level. 
-        Could I step it up? Of course I could. 
-        Could I do something for others as well? Of course.
     </p>
+
+    <p class="question">Have I really learned to feel exposed? To a level.</p>
+    <p class="question">Could I step it up? Of course I could.</p>
+    <p class="question">Could I do something for others as well? Of course.</p>
 
     <p>
         Getting this website open and deployed from the first moments helped despite the anxiety of the unknown.


### PR DESCRIPTION
This PR introduces basic styling improvements and two new text classes for the About page:

- Increases gap for `.about-section`
- Adds transition to `.about-section`
- Adds `.about-section:hover`, `.about-section h3`, and `.about-section p` styles
- `.highlight` for key sentences (italic with left border)
- `.question` for reflective questions (italic only, no border)

Blade partials have been updated to apply these classes.