### PR TITLE
refactor(contact): introduce and use config mail.to 

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -31,7 +31,7 @@ class ContactController extends Controller
         ]);
 
         Mail::raw($validated['message'], function ($message) use ($validated) {
-            $message->to(env('MAIL_TO_ADDRESS'))
+            $message->to(config('mail.to'))
                     ->subject("Message from: {$validated['name']}")
                     ->replyTo($validated['email']);
         });

--- a/config/mail.php
+++ b/config/mail.php
@@ -115,4 +115,6 @@ return [
         'name' => env('MAIL_FROM_NAME', 'Example'),
     ],
 
+    'to' => env('MAIL_TO_ADDRESS', 'hello@example.com'),
+
 ];

--- a/resources/views/pages/contact.blade.php
+++ b/resources/views/pages/contact.blade.php
@@ -18,7 +18,11 @@
     </p>
     <p>
         You can send me a message on
-        <a href="mailto:{{ $user->email }}">{{ $user->email }}</a> or use the form below.
+        <a  href="mailto:{{ config('mail.to') }}" 
+            aria-label="Send an email to {{ config('mail.to') }}">
+            {{ config('mail.to') }}
+        </a> 
+        or use the form below.
     </p>
 
     @if(session('success'))


### PR DESCRIPTION
## Changes

- Introduced 'to' => env('MAIL_TO_ADDRESS') in config/mail.php.

- Updated ContactController to send contact form emails via config('mail.to') instead of env().

- Updated contact.blade.php to display the email via config('mail.to') and added an aria-label for accessibility.


## Testing

- Contact form messages are sent correctly to the email defined in .env.

- Email displayed on the contact page is clickable.