### PR TITLE
fix(ci): improve Laravel deployment workflow for Hostinger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,8 +37,11 @@ jobs:
       - name: Build assets
         run: npm run build
 
-      # Deploy everything except public/ to parent folder
-      - name: Deploy Laravel backend files
+      # Deploy the Laravel application to the domain root.
+      # Hostinger serves websites from public_html, which should point to Laravel's public/ directory.
+      # The public_html symlink is configured separately to expose only publicly accessible files.
+      # Keeping the full Laravel structure outside the public directory improves security.
+      - name: Deploy Laravel application
         uses: SamKirkland/FTP-Deploy-Action@v4.3.6
         with:
           server: ${{ secrets.HOSTINGER_HOST }}
@@ -46,23 +49,10 @@ jobs:
           password: ${{ secrets.HOSTINGER_PASS }}
           protocol: ftp
           port: 21
-          local-dir: ./            # whole repo
+          local-dir: ./
           exclude: |
-            public/**       
             node_modules/**
             .git/**
+            .github/**
             tests/**
-            vendor/**
-          server-dir: ../          # parent of public_html
-
-      # Deploy only public/ to public_html
-      - name: Deploy public folder
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.6
-        with:
-          server: ${{ secrets.HOSTINGER_HOST }}
-          username: ${{ secrets.HOSTINGER_USER }}
-          password: ${{ secrets.HOSTINGER_PASS }}
-          protocol: ftp
-          port: 21
-          local-dir: ./public/
-          server-dir: ./
+          server-dir: domains/a-mamal.com/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,9 +38,6 @@ jobs:
         run: npm run build
 
       # Deploy the Laravel application to the domain root.
-      # Hostinger serves websites from public_html, which should point to Laravel's public/ directory.
-      # The public_html symlink is configured separately to expose only publicly accessible files.
-      # Keeping the full Laravel structure outside the public directory improves security.
       - name: Deploy Laravel application
         uses: SamKirkland/FTP-Deploy-Action@v4.3.6
         with:
@@ -56,3 +53,20 @@ jobs:
             .github/**
             tests/**
           server-dir: domains/a-mamal.com/
+
+
+      # Configure public_html symlink
+      # Hostinger uses public_html as the document root.
+      # This exposes only Laravel's public directory while keeping application files outside the web root.
+      - name: Configure public_html symlink
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.HOSTINGER_SSH_HOST }}
+          username: ${{ secrets.HOSTINGER_SSH_USER }}
+          password: ${{ secrets.HOSTINGER_SSH_PASSWORD }}
+          port: ${{ secrets.HOSTINGER_SSH_PORT }}
+          script: |
+            set -e
+            cd ~/domains/a-mamal.com
+            rm -rf ./public_html
+            ln -s ./public public_html

--- a/README.md
+++ b/README.md
@@ -596,9 +596,11 @@ When your feature or fix is ready:
 
 ## Deployment
 
-- Live at: https://a-mamal.dev/
+- Live at: https://a-mamal.com/
 - Hosting: Hostinger.
-- Automation: Deployment handled via FTP Deploy Action
+- Automation: Deployment handled via GitHub Actions.
+   - Laravel application files are deployed using FTP Deploy Action.
+   - Hostinger's `public_html` directory is configured via SSH as a symlink to Laravel's `public/` directory.
 - Database: Credentials managed via .env and .env.production
 
 ---
@@ -609,6 +611,7 @@ When your feature or fix is ready:
 - [GitHub Actions](https://github.com/features/actions)
 - [shivammathur/setup-php](https://github.com/shivammathur/setup-php) (PHP 8.4)
 - [FTP-Deploy-Action](https://github.com/SamKirkland/FTP-Deploy-Action)
+- [appleboy/ssh-action](https://github.com/appleboy/ssh-action)
 
 ### 🛠️ Development  
 - [Laravel Herd](https://herd.laravel.com/) (local PHP + MariaDB)


### PR DESCRIPTION
## Summary

Updates the Laravel deployment workflow to better support Hostinger's hosting structure.


## Changes

- Updated the GitHub Actions deployment workflow.
- Deploys the full Laravel application outside the web root.
- Added SSH automation to configure `public_html` as a symlink to Laravel's `public/` directory.
- Updated README Deployment documentation and Tooling & Acknowledgments.


## Why

Laravel applications should only expose the `public/` directory to the web. Hostinger uses `public_html` as the document root, so the deployment now keeps the application structure outside the public web root while exposing only the required files.


## Testing

- Deployment will be validated through GitHub Actions after merging.