### PR TITLE
refactor(deploy): install Composer dependencies on Hostinger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,17 +14,6 @@ jobs:
       # Pull code from GitHub
       - uses: actions/checkout@v7
 
-      # Set up PHP 8.4 (for Laravel)
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.4
-          extensions: mbstring, bcmath, curl, xml
-
-      # Install Composer dependencies
-      - name: Install Composer dependencies
-        run: composer install --no-dev --optimize-autoloader
-
       # Set up Node and build Vite assets
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -32,7 +21,7 @@ jobs:
           node-version: 20
 
       - name: Install NPM packages
-        run: npm install
+        run: npm ci
 
       - name: Build assets
         run: npm run build
@@ -48,12 +37,27 @@ jobs:
           port: 21
           local-dir: ./
           exclude: |
+            vendor/**
             node_modules/**
             .git/**
             .github/**
             tests/**
           server-dir: ../
 
+      # Install Composer dependencies on Hostinger
+      - name: Install Composer dependencies on server
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.HOSTINGER_SSH_HOST }}
+          username: ${{ secrets.HOSTINGER_SSH_USER }}
+          password: ${{ secrets.HOSTINGER_SSH_PASSWORD }}
+          port: ${{ secrets.HOSTINGER_SSH_PORT }}
+          script: |
+            set -e
+            cd ~/domains/a-mamal.com
+            composer2 install --no-dev --optimize-autoloader
+            php artisan optimize:clear
+            php artisan optimize
 
       # Configure public_html symlink
       # Hostinger uses public_html as the document root.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       # Pull code from GitHub
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       # Set up PHP 8.4 (for Laravel)
       - name: Setup PHP
@@ -27,7 +27,7 @@ jobs:
 
       # Set up Node and build Vite assets
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 
@@ -39,7 +39,7 @@ jobs:
 
       # Deploy the Laravel application to the domain root.
       - name: Deploy Laravel application
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.6
+        uses: SamKirkland/FTP-Deploy-Action@v4.4.0
         with:
           server: ${{ secrets.HOSTINGER_HOST }}
           username: ${{ secrets.HOSTINGER_USER }}

--- a/README.md
+++ b/README.md
@@ -600,6 +600,9 @@ When your feature or fix is ready:
 - Hosting: Hostinger.
 - Automation: Deployment handled via GitHub Actions.
    - Laravel application files are deployed using FTP Deploy Action.
+   - The `vendor` directory is excluded from FTP deployment.
+   - Composer dependencies are installed directly on the Hostinger server using Composer (`composer2`).
+   - Laravel caches are optimized after deployment.
    - Hostinger's `public_html` directory is configured via SSH as a symlink to Laravel's `public/` directory.
 - Database: Credentials managed via .env and .env.production
 
@@ -609,7 +612,6 @@ When your feature or fix is ready:
 
 ### 🚀 Deployment
 - [GitHub Actions](https://github.com/features/actions)
-- [shivammathur/setup-php](https://github.com/shivammathur/setup-php) (PHP 8.4)
 - [FTP-Deploy-Action](https://github.com/SamKirkland/FTP-Deploy-Action)
 - [appleboy/ssh-action](https://github.com/appleboy/ssh-action)
 


### PR DESCRIPTION
## Summary

- Updated GitHub Actions versions
- Updated the deployment workflow to install Composer dependencies directly on Hostinger instead of uploading the `vendor` directory.
- Excluded `vendor/` from FTP deployment to reduce upload time and avoid FTP connection issues.
- Added server-side Laravel optimization steps after dependency installation.
- Updated deployment documentation in the README.


## Why

Uploading the `vendor` directory through FTP was slow and caused deployment failures due to the large number of files being transferred.