### PR TITLE
fix(css): correct collapsed navigation padding

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -305,7 +305,7 @@ button.sidebar-toggle {
 /* Center icons when sidebar collapsed */
 .main-header.collapsed .site-nav a {    
     justify-content: center;
-    padding: var(--space-xs 0);
+    padding: var(--space-xs) 0;
 }
 
 /* Hide text when sidebar collapsed */


### PR DESCRIPTION
## Summary

Correct an invalid CSS custom property declaration in the collapsed sidebar navigation.


## Changes

- fix the collapsed navigation link padding declaration
- ensure the CSS passes the Vite production build